### PR TITLE
Navigation code change

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -5,6 +5,7 @@
   */
 /area
 	name = "Space"
+	var/navigation_area_name /// when multiple areas should have the same name, set this. get_area_navigation_name() proc will use name variable if this is null
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "unknown"
 	layer = AREA_LAYER
@@ -657,3 +658,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		. = FALSE
 	if(mood_job_reverse)
 		return !.  // the most eye bleeding syntax ive written
+
+/// returns a name of the area. some subtype area needs to return different value.
+/area/proc/get_navigation_area_name()
+	return navigation_area_name || name

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -514,7 +514,12 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "navigate"
 	layer = OBJ_LAYER
 
+	/// navigation_id automatically sets to its area name (Bridge, Hydroponics, etc)
+	/// If you want to use a dedicated name for a specific area, set this value in DMM.
+	/// example) navigation_id = "Bartender's storage"
 	var/navigation_id
+
+	// Note: if multiple area needs a standard name, use "navigation_area_name"
 
 /obj/effect/landmark/navigate_destination/Initialize(mapload)
 	. = ..()
@@ -539,11 +544,17 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 		actual_key = "[navigation_id] ([++fail_assoc_count])"
 	GLOB.navigate_destinations[navigation_id] = src
 
+/// Checks if this destination is available to a user.
 /obj/effect/landmark/navigate_destination/proc/is_available_to_user(mob/user)
 	if(!isatom(src) || !compare_z_with(user) || get_dist(get_turf(src), user) > MAX_NAVIGATE_RANGE)
 		return FALSE
 	return TRUE
 
+/// Checks if each z of this destination and a user.
+/// * FALSE: target destination doesn't exist, or z-groups are different (i.e. Station to Lavaland)
+/// * 1: very exactly same z
+/// * 16 (UP): target destination is above the user
+/// * 32 (DOWN): target destination is below the user
 /obj/effect/landmark/navigate_destination/proc/compare_z_with(mob/user)
 	var/turf/target_turf = get_turf(src)
 	if(!target_turf)


### PR DESCRIPTION
* Now the list shows multiple floor destination even if z is different (as long as the z groups are the same)
* Nuked all subtype destination landmarks. Just use a single type.
* You don't have to make a subtype of a landmark type to put a navigation
only `/obj/effect/landmark/navigate_destination` is enough for mapping (but you need to give `navigation_id` a custom name if the area name is off)