### PR TITLE
Fixes cyborg glass stacks not being used correctly

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral/glass.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass.dm
@@ -25,6 +25,8 @@
 	point_value = 1
 	tableVariant = /obj/structure/table/glass
 	matter_amount = 4
+	cost = 500
+	source = /datum/robot_energy_storage/glass
 
 /obj/item/stack/sheet/glass/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to slice [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes https://github.com/BeeStation/BeeStation-Hornet/issues/10654

Fixes error from https://github.com/BeeStation/BeeStation-Hornet/pull/10380 

I didnt assign the glass stacks to the cyborgs correct storage, meaning energy wouldn't convert into stacks, and cyborgs could even permanently lose their glass stacks if they didn't refill from the singular stack at roundstart.

This sets the correct cost and correct energy pathing

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes bug

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/Tsar-Salat/BeeStation-Salatland/assets/62388554/c2d09050-2c4a-489c-b667-c8a25ca080bc



</details>

## Changelog
:cl:
fix: fixes bug with cyborg glass stacks when crafting or using on tableframes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
